### PR TITLE
sinks/sns: add support for FIFO topics (MessageGroupId)

### DIFF
--- a/pkg/sinks/sns.go
+++ b/pkg/sinks/sns.go
@@ -9,9 +9,10 @@ import (
 )
 
 type SNSConfig struct {
-	TopicARN string                 `yaml:"topicARN"`
-	Region   string                 `yaml:"region"`
-	Layout   map[string]interface{} `yaml:"layout"`
+	TopicARN       string                 `yaml:"topicARN"`
+	MessageGroupId string                 `yaml:"MessageGroupId"`
+	Region         string                 `yaml:"region"`
+	Layout         map[string]interface{} `yaml:"layout"`
 }
 
 type SNSSink struct {
@@ -42,6 +43,7 @@ func (s *SNSSink) Send(ctx context.Context, ev *kube.EnhancedEvent) error {
 
 	_, err := s.svc.PublishWithContext(ctx, &sns.PublishInput{
 		Message:  aws.String(string(toSend)),
+		MessageGroupId: aws.String(s.cfg.MessageGroupId),
 		TopicArn: aws.String(s.cfg.TopicARN),
 	})
 


### PR DESCRIPTION
Add support for FIFO topics to keep events ordered